### PR TITLE
Delete repeated header link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,12 +93,6 @@ enableRobotsTXT = true
     weight = 6
 
   [[menu.main]]
-    identifier = "github"
-    pre = "<span data-feather='github'></span>"
-    url = "https://github.com/ben9583"
-    weight = 7
-
-  [[menu.main]]
     identifier = "rss"
     pre = "<span data-feather='rss'></span>"
     url = "/index.xml"


### PR DESCRIPTION
Given the hyperlink in the default home page, I thought the header link was unnecessary.